### PR TITLE
Change symlink targets

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -78,8 +78,9 @@ class Neovim < Formula
   def caveats; <<-EOS.undent
       The Neovim executable is called 'nvim'. To use your existing Vim
       configuration:
-          ln -s ~/.vimrc ~/.nvimrc
-          ln -s ~/.vim ~/.nvim
+          ln -s ~/.vimrc ~/.config/nvim/init.vim
+          ln -s ~/.vim ~/.config/nvim
+          ln -s ~/.vim/colors ~/.config/nvim/colors
       See ':help nvim' for more information on Neovim.
 
       When upgrading Neovim, check the following page for breaking changes:


### PR DESCRIPTION
Change symlink targets to point to the new location of Neovim's config files. I think the change was fairly recent, as per [this Reddit thread](https://www.reddit.com/r/neovim/comments/3qgsza/psa_if_neovim_stopped_loading_your_nvimrc_after/), which points to [issue #78](https://github.com/neovim/neovim/issues/78).
